### PR TITLE
Make document well-formed and valid

### DIFF
--- a/Conversion test files/MinimalFGDC_Title_SpatialExtent.xml
+++ b/Conversion test files/MinimalFGDC_Title_SpatialExtent.xml
@@ -1,20 +1,21 @@
-<?xml version="1.0" encoding="UTF-8"?><!DOCTYPE metadata SYSTEM "http://www.fgdc.gov/metadata/fgdc-std-001-1998.dtd"><metadata layerid="CAMBRIDGE14PUBLICLIBRARIES">
-<!-- Minimal FGDC xml record. 1 core ontology element: Title, and 1 geospatial extension ontology set of elements: bounding box
--->
-<idinfo>
-<citation>
-<citeinfo>
-<title>Public Libraries, Cambridge, Massachusetts, 2014</title>
-<citeinfo>
-<spdom>
-<bounding>
-<!-- bounding box elements need to be converted to a single WKT statement
--->
-<westbc>-71.146912</westbc>
-<eastbc>-71.084684</eastbc>
-<northbc>42.392720</northbc>
-<southbc>42.363838</southbc>
-</bounding>
-</spdom>
-</idinfo>
+<?xml version="1.0" encoding="UTF-8"?><!DOCTYPE metadata SYSTEM "http://www.fgdc.gov/metadata/fgdc-std-001-1998.dtd">
+<metadata layerid="CAMBRIDGE14PUBLICLIBRARIES">
+	<!-- Minimal FGDC xml record. 1 core ontology element: Title, and 1 geospatial 
+		extension ontology set of elements: bounding box -->
+	<idinfo>
+		<citation>
+			<citeinfo>
+				<title>Public Libraries, Cambridge, Massachusetts, 2014</title>
+			</citeinfo>
+		</citation>
+		<spdom>
+			<bounding>
+				<!-- bounding box elements need to be converted to a single WKT statement -->
+				<westbc>-71.146912</westbc>
+				<eastbc>-71.084684</eastbc>
+				<northbc>42.392720</northbc>
+				<southbc>42.363838</southbc>
+			</bounding>
+		</spdom>
+	</idinfo>
 </metadata>


### PR DESCRIPTION
Document was not well-formed XML -- missing some closing tags.
Also, did not validate against referenced DTD.